### PR TITLE
#6 Rework Assessment Types

### DIFF
--- a/src/main/java/com/fortify/fod/fodapi/FodEnums.java
+++ b/src/main/java/com/fortify/fod/fodapi/FodEnums.java
@@ -107,4 +107,40 @@ public class FodEnums {
             }
         }
     }
+
+    public enum EntitlementPreferenceType {
+        SingleScan(1),
+        Subscription(2);
+
+        private final int _val;
+
+        EntitlementPreferenceType(int val) {
+            this._val = val;
+        }
+
+        public int getValue() {
+            return this._val;
+        }
+
+        public String toString() {
+            switch (this._val) {
+                case 2:
+                    return "Subscription";
+                case 1:
+                default:
+                    return "Single Scan";
+            }
+        }
+
+        public static EntitlementPreferenceType fromInt(int val) {
+            switch (val) {
+                case 2:
+                    return Subscription;
+                case 1:
+                    return SingleScan;
+                default:
+                    return null;
+            }
+        }
+    }
 }

--- a/src/main/java/com/fortify/fod/fodapi/controllers/StaticScanController.java
+++ b/src/main/java/com/fortify/fod/fodapi/controllers/StaticScanController.java
@@ -56,7 +56,7 @@ public class StaticScanController extends ControllerBase {
             fragUrl += "&entitlementId=" + assessment.getEntitlementId();
             fragUrl += "&entitlementFrequencyType=" + assessment.getFrequencyTypeId();
             fragUrl += "&isBundledAssessment=" + assessment.isBundledAssessment();
-            if (assessment.getParentAssessmentTypeId() != 0)
+            if (assessment.getParentAssessmentTypeId() != 0 && assessment.isBundledAssessment())
                 fragUrl += "&parentAssessmentTypeId=" + assessment.getParentAssessmentTypeId();
             if (fc.bsiUrl.hasLanguageLevel())
                 fragUrl += "&languageLevel=" + fc.bsiUrl.getLanguageLevel();

--- a/src/main/java/com/fortify/fod/fodapi/controllers/StaticScanController.java
+++ b/src/main/java/com/fortify/fod/fodapi/controllers/StaticScanController.java
@@ -46,7 +46,7 @@ public class StaticScanController extends ControllerBase {
 
             // Get entitlement info
             ReleaseAssessmentTypeDTO assessment = api.getReleaseController()
-                    .getAssessmentType(fc.bsiUrl.getProjectVersionId(), fc.bsiUrl.getAssessmentTypeId());
+                    .getAssessmentType(fc);
 
             // Build 'static' portion of url
             String fragUrl = api.getBaseUrl() + "/api/v3/releases/" + fc.bsiUrl.getProjectVersionId() +
@@ -55,7 +55,9 @@ public class StaticScanController extends ControllerBase {
             fragUrl += "&technologyStack=" + fc.bsiUrl.getTechnologyStack();
             fragUrl += "&entitlementId=" + assessment.getEntitlementId();
             fragUrl += "&entitlementFrequencyType=" + assessment.getFrequencyTypeId();
-            // ^^ This isn't actually working, it always puts 1 for the Frequency Type.
+            fragUrl += "&isBundledAssessment=" + assessment.isBundledAssessment();
+            if (assessment.getParentAssessmentTypeId() != 0)
+                fragUrl += "&parentAssessmentTypeId=" + assessment.getParentAssessmentTypeId();
             if (fc.bsiUrl.hasLanguageLevel())
                 fragUrl += "&languageLevel=" + fc.bsiUrl.getLanguageLevel();
             if (fc.hasScanPreferenceType())
@@ -65,9 +67,6 @@ public class StaticScanController extends ControllerBase {
             fragUrl += "&doSonatypeScan=" + fc.runSonatypeScan;
             fragUrl += "&isRemediationScan=" + fc.isRemediationScan;
             fragUrl += "&excludeThirdPartyLibs=" + fc.excludeThirdPartyLibs;
-            fragUrl += "&isBundledAssessment=" + fc.isBundledAssessment;
-            if (fc.hasParentAssessmentTypeId())
-            	fragUrl += "&parentAssessmentTypeId=" + fc.parentAssessmentTypeId;
 
             Gson gson = new Gson();
 

--- a/src/main/java/com/fortify/fod/fodapi/models/ReleaseAssessmentTypeDTO.java
+++ b/src/main/java/com/fortify/fod/fodapi/models/ReleaseAssessmentTypeDTO.java
@@ -10,6 +10,8 @@ public class ReleaseAssessmentTypeDTO {
     private int frequencyTypeId;
     private int units;
     private int unitsAvailable;
+    private int parentAssessmentTypeId;
+    private boolean isBundledAssessment;
 
     public int getAssessmentTypeId() {
         return assessmentTypeId;
@@ -49,6 +51,14 @@ public class ReleaseAssessmentTypeDTO {
 
     public int getUnitsAvailable() {
         return unitsAvailable;
+    }
+
+    public int getParentAssessmentTypeId() {
+        return parentAssessmentTypeId;
+    }
+
+    public boolean isBundledAssessment() {
+        return isBundledAssessment;
     }
 
 }

--- a/src/main/java/com/fortify/fod/parser/FortifyCommands.java
+++ b/src/main/java/com/fortify/fod/parser/FortifyCommands.java
@@ -86,7 +86,7 @@ public class FortifyCommands {
     private static final String ENTITLEMENT_PREFERENCE = "-entitlementPreference";
     private static final String ENTITLEMENT_PREFERENCE_SHORT = "-ep";
     @Parameter(names = { ENTITLEMENT_PREFERENCE, ENTITLEMENT_PREFERENCE_SHORT },
-            description = "preferred entitlement type (Single Scan or Subscription)",
+            description = "preferred entitlement type (SingleScan or Subscription)",
             converter = EntitlementPreferenceTypeConverter.class,
             required = true)
     public FodEnums.EntitlementPreferenceType entitlementPreference = null;
@@ -94,7 +94,7 @@ public class FortifyCommands {
     private static final String PURCHASE_ENTITLEMENT = "-purchaseEntitlement";
     private static final String PURCHASE_ENTITLEMENT_SHORT = "-purchase";
     @Parameter(names = { PURCHASE_ENTITLEMENT, PURCHASE_ENTITLEMENT_SHORT },
-            description = "whether to purchase an entitlement if needed")
+            description = "whether to purchase an entitlement if available")
     public boolean purchaseEntitlement = false;
 
     private static final String EXCLUDE_THIRD_PARTY_LIBS = "-excludeThirdPartyApps";

--- a/src/main/java/com/fortify/fod/parser/FortifyCommands.java
+++ b/src/main/java/com/fortify/fod/parser/FortifyCommands.java
@@ -2,10 +2,7 @@ package com.fortify.fod.parser;
 
 import com.beust.jcommander.Parameter;
 import com.fortify.fod.fodapi.FodEnums;
-import com.fortify.fod.parser.converters.AuditPreferenceTypeConverter;
-import com.fortify.fod.parser.converters.BsiUrlConverter;
-import com.fortify.fod.parser.converters.FileConverter;
-import com.fortify.fod.parser.converters.ScanPreferenceTypeConverter;
+import com.fortify.fod.parser.converters.*;
 import com.fortify.fod.parser.validators.BsiUrlValidator;
 import com.fortify.fod.parser.validators.FileValidator;
 
@@ -80,26 +77,25 @@ public class FortifyCommands {
                 scanPreferenceType.getValue() != 0;
     }
 
-    private static final String ENTITLEMENT_ID = "-entitlementId";
-    private static final String ENTITLEMENT_ID_SHORT = "-e";
-    @Parameter(names = { ENTITLEMENT_ID, ENTITLEMENT_ID_SHORT },
-            description = "entitlement id")
-    public int entitlementId;
-
-    private static final String PARENT_ASSESSMENT_TYPE_ID = "-parentAssessmentTypeId";
-    private static final String PARENT_ASSESSMENT_TYPE_ID_SHORT = "-pa";
-    @Parameter(names = { PARENT_ASSESSMENT_TYPE_ID, PARENT_ASSESSMENT_TYPE_ID_SHORT },
-            description = "Parent Assessment Type ID for Bundled Assessments")
-    public int parentAssessmentTypeId;
-    public boolean hasParentAssessmentTypeId() {
-        return parentAssessmentTypeId != 0;
-    }
-
     private static final String IS_BUNDLED_ASSESSMENT = "-isBundledAssessment";
     private static final String IS_BUNDLED_ASSESSMENT_SHORT = "-b";
     @Parameter(names = { IS_BUNDLED_ASSESSMENT, IS_BUNDLED_ASSESSMENT_SHORT },
             description = "whether the scan is a bundled assessment")
     public boolean isBundledAssessment = false;
+
+    private static final String ENTITLEMENT_PREFERENCE = "-entitlementPreference";
+    private static final String ENTITLEMENT_PREFERENCE_SHORT = "-ep";
+    @Parameter(names = { ENTITLEMENT_PREFERENCE, ENTITLEMENT_PREFERENCE_SHORT },
+            description = "preferred entitlement type (Single Scan or Subscription)",
+            converter = EntitlementPreferenceTypeConverter.class,
+            required = true)
+    public FodEnums.EntitlementPreferenceType entitlementPreference = null;
+
+    private static final String PURCHASE_ENTITLEMENT = "-purchaseEntitlement";
+    private static final String PURCHASE_ENTITLEMENT_SHORT = "-purchase";
+    @Parameter(names = { PURCHASE_ENTITLEMENT, PURCHASE_ENTITLEMENT_SHORT },
+            description = "whether to purchase an entitlement if needed")
+    public boolean purchaseEntitlement = false;
 
     private static final String EXCLUDE_THIRD_PARTY_LIBS = "-excludeThirdPartyApps";
     private static final String EXCLUDE_THIRD_PARTY_LIBS_SHORT = "-x";

--- a/src/main/java/com/fortify/fod/parser/converters/EntitlementPreferenceTypeConverter.java
+++ b/src/main/java/com/fortify/fod/parser/converters/EntitlementPreferenceTypeConverter.java
@@ -1,0 +1,16 @@
+package com.fortify.fod.parser.converters;
+
+import com.beust.jcommander.IStringConverter;
+import com.fortify.fod.fodapi.FodEnums;
+
+public class EntitlementPreferenceTypeConverter  implements IStringConverter<FodEnums.EntitlementPreferenceType> {
+    @Override
+    public FodEnums.EntitlementPreferenceType convert(String value) {
+        try {
+            int n = Integer.parseInt(value);
+            return FodEnums.EntitlementPreferenceType.fromInt(n);
+        } catch(NumberFormatException ex) {
+            return FodEnums.EntitlementPreferenceType.valueOf(value);
+        }
+    }
+}


### PR DESCRIPTION
This should fix issue #6 

Removed:
-e, -f, -pa

Added:
-purchase, -b, -ep

This should allow users to properly select a frequency type and whether they want to allow purchasing if available.